### PR TITLE
fix: 变更Modal组件的引入方式

### DIFF
--- a/modal/MFTranslucentModal.harmony.js
+++ b/modal/MFTranslucentModal.harmony.js
@@ -21,6 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import { Modal } from 'react-native';
+import Modal from 'react-native-translucent-modal/modal/MFTranslucentModal.ios'
 
 export default Modal;


### PR DESCRIPTION
<!-- 感谢您提交PR！请按照模板填写，以便审阅者可以轻松理解和评估代码变更的影响。Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

closes #6 
该库源库的设计初衷是为了解决Android端模态框无法填充状态栏的问题，而IOS和HarmonyOS端天然支持填充状态栏；本次主要是修改了Modal模块的引入方式：将文件MFTranslucentModal.harmony.js中的import { Modal } from 'react-native'；修改为：import Modal from "react-native-translucent-modal/modal/MFTranslucentModal.ios"；该改动不影响库的使用

## Test Plan


## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)